### PR TITLE
Issue #57 シーズン詳細画面に総合pt推移グラフを追加

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,7 +20,8 @@
     "next": "15.5.4",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "react-redux": "^9.2.0"
+    "react-redux": "^9.2.0",
+    "recharts": "^3.8.1"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/frontend/src/app/league/[leagueId]/season/[seasonId]/hooks/index.ts
+++ b/frontend/src/app/league/[leagueId]/season/[seasonId]/hooks/index.ts
@@ -23,12 +23,41 @@ type SeasonChartSeries = {
   colorClassName: string;
 };
 
+type SeasonChartViewSeries = SeasonChartSeries & {
+  strokeColor: string;
+};
+
 type SeasonChartData = {
   matchIndex: number;
   [userId: string]: number;
 };
 
 const formatPercent = (value: number) => `${value.toFixed(2)}%`;
+
+const CHART_STROKE_COLORS = [
+  "#ef4444",
+  "#3b82f6",
+  "#22c55e",
+  "#eab308",
+  "#a855f7",
+  "#ec4899",
+  "#f97316",
+  "#0ea5e9",
+  "#10b981",
+  "#f59e0b",
+  "#84cc16",
+  "#14b8a6",
+  "#06b6d4",
+  "#6366f1",
+  "#8b5cf6",
+  "#d946ef",
+  "#f43f5e",
+  "#db2777",
+  "#a16207",
+  "#78716c",
+  "#6b7280",
+  "#111827",
+];
 
 const colorClassNames = Object.values(COLOR_MAP);
 
@@ -181,6 +210,42 @@ export const useSeasonPage = () => {
     return buildSeasonChartData(season);
   }, [season]);
 
+  const chartSeries: SeasonChartViewSeries[] = React.useMemo(
+    () =>
+      pointProgressionChart.series.map((item, index) => ({
+        userId: item.userId,
+        userName: item.userName,
+        colorClassName: item.colorClassName,
+        strokeColor:
+          CHART_STROKE_COLORS[index % CHART_STROKE_COLORS.length] ?? "#111827",
+      })),
+    [pointProgressionChart.series]
+  );
+
+  const [visibleUserIds, setVisibleUserIds] = React.useState<string[]>([]);
+
+  React.useEffect(() => {
+    setVisibleUserIds(chartSeries.map((item) => item.userId));
+  }, [chartSeries]);
+
+  const visibleSeries: SeasonChartViewSeries[] = React.useMemo(
+    () =>
+      chartSeries.filter((item) =>
+        visibleUserIds.some((userId) => userId === item.userId)
+      ),
+    [chartSeries, visibleUserIds]
+  );
+
+  const handleToggleChartSeries = React.useCallback((userId: string) => {
+    setVisibleUserIds((prev) => {
+      if (prev.some((id) => id === userId)) {
+        return prev.filter((id) => id !== userId);
+      }
+
+      return [...prev, userId];
+    });
+  }, []);
+
   const handleStartRecording = React.useCallback(() => {
     const leagueId = params.leagueId;
     const seasonId = params.seasonId;
@@ -197,8 +262,12 @@ export const useSeasonPage = () => {
     season,
     titles,
     pointProgressionChart,
+    chartSeries,
+    visibleSeries,
+    visibleUserIds,
     loading,
     error,
     handleStartRecording,
+    handleToggleChartSeries,
   };
 };

--- a/frontend/src/app/league/[leagueId]/season/[seasonId]/hooks/index.ts
+++ b/frontend/src/app/league/[leagueId]/season/[seasonId]/hooks/index.ts
@@ -2,11 +2,14 @@ import * as React from "react";
 
 import { useParams, useRouter } from "next/navigation";
 
+import { COLOR_MAP } from "@/constants/color-map";
 import { ApiError } from "@/lib/api/core";
 import { fetchSeasonDetail } from "@/lib/api/seasons";
 
 const DEFAULT_ERROR_MESSAGE =
   "シーズン詳細の取得に失敗しました。時間をおいて再度お試しください。";
+
+type SeasonDetail = Awaited<ReturnType<typeof fetchSeasonDetail>>;
 
 type Title = {
   label: string;
@@ -14,7 +17,67 @@ type Title = {
   value: string;
 };
 
+type SeasonChartSeries = {
+  userId: string;
+  userName: string;
+  colorClassName: string;
+};
+
+type SeasonChartData = {
+  matchIndex: number;
+  [userId: string]: number;
+};
+
 const formatPercent = (value: number) => `${value.toFixed(2)}%`;
+
+const colorClassNames = Object.values(COLOR_MAP);
+
+const buildSeasonChartData = (season: SeasonDetail) => {
+  const series: SeasonChartSeries[] = season.pointProgressions.map(
+    (progression, index) => ({
+      userId: progression.userId,
+      userName: progression.userName,
+      colorClassName: colorClassNames[index % colorClassNames.length],
+    })
+  );
+
+  const progressionByUser = new Map(
+    season.pointProgressions.map((progression) => [
+      progression.userId,
+      new Map(
+        progression.points.map((point) => [point.matchIndex, point.totalPoints])
+      ),
+    ])
+  );
+
+  const latestPointByUser = new Map<string, number>();
+
+  const chartData: SeasonChartData[] = Array.from(
+    { length: season.totalMatchCount },
+    (_, index) => {
+      const matchIndex = index + 1;
+      const row: SeasonChartData = { matchIndex };
+
+      series.forEach((item) => {
+        const progression = progressionByUser.get(item.userId);
+        const currentPoint = progression?.get(matchIndex);
+        if (typeof currentPoint === "number") {
+          latestPointByUser.set(item.userId, currentPoint);
+        }
+
+        row[item.userId] = latestPointByUser.get(item.userId) ?? 0;
+      });
+
+      return row;
+    }
+  );
+
+  return {
+    series,
+    chartData,
+    isChartEmpty: season.totalMatchCount === 0 || series.length === 0,
+  };
+};
 
 export const useSeasonPage = () => {
   const router = useRouter();
@@ -106,6 +169,18 @@ export const useSeasonPage = () => {
     ].filter((title): title is Title => title !== null);
   }, [season]);
 
+  const pointProgressionChart = React.useMemo(() => {
+    if (!season) {
+      return {
+        series: [] as SeasonChartSeries[],
+        chartData: [] as SeasonChartData[],
+        isChartEmpty: true,
+      };
+    }
+
+    return buildSeasonChartData(season);
+  }, [season]);
+
   const handleStartRecording = React.useCallback(() => {
     const leagueId = params.leagueId;
     const seasonId = params.seasonId;
@@ -121,6 +196,7 @@ export const useSeasonPage = () => {
     leagueId: params.leagueId,
     season,
     titles,
+    pointProgressionChart,
     loading,
     error,
     handleStartRecording,

--- a/frontend/src/app/league/[leagueId]/season/[seasonId]/page.tsx
+++ b/frontend/src/app/league/[leagueId]/season/[seasonId]/page.tsx
@@ -73,6 +73,30 @@ const SeasonPage: React.FC = () => {
     [pointProgressionChart.series]
   );
 
+  const [visibleUserIds, setVisibleUserIds] = React.useState<string[]>([]);
+
+  React.useEffect(() => {
+    setVisibleUserIds(chartSeries.map((item) => item.userId));
+  }, [chartSeries]);
+
+  const visibleSeries = React.useMemo(
+    () =>
+      chartSeries.filter((item) =>
+        visibleUserIds.some((userId) => userId === item.userId)
+      ),
+    [chartSeries, visibleUserIds]
+  );
+
+  const handleToggleSeries = React.useCallback((userId: string) => {
+    setVisibleUserIds((prev) => {
+      if (prev.some((id) => id === userId)) {
+        return prev.filter((id) => id !== userId);
+      }
+
+      return [...prev, userId];
+    });
+  }, []);
+
   if (loading) {
     return (
       <div className="flex-1 bg-white min-h-full font-jp">
@@ -137,13 +161,33 @@ const SeasonPage: React.FC = () => {
 
         <section className="mb-8">
           <SectionCard title="総合pt推移" bodyClassName="p-4">
-            <SeasonPointProgressionChart
-              data={pointProgressionChart.chartData}
-              series={chartSeries}
-            />
+            {pointProgressionChart.isChartEmpty ? (
+              <div className="mb-3 flex h-[220px] w-full items-center justify-center rounded-md bg-gray-50 text-sm text-text-muted">
+                まだ対局データがないため、グラフを表示できません
+              </div>
+            ) : visibleSeries.length > 0 ? (
+              <SeasonPointProgressionChart
+                data={pointProgressionChart.chartData}
+                series={visibleSeries}
+              />
+            ) : (
+              <div className="mb-3 flex h-[220px] w-full items-center justify-center rounded-md bg-gray-50 text-sm text-text-muted">
+                凡例からプレイヤーを選択するとグラフを表示できます
+              </div>
+            )}
             <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs">
               {chartSeries.map((item) => (
-                <div key={item.userId} className="flex items-center gap-1">
+                <button
+                  key={item.userId}
+                  type="button"
+                  className={clsx(
+                    "flex items-center gap-1 transition-opacity",
+                    visibleUserIds.some((userId) => userId === item.userId)
+                      ? "opacity-100"
+                      : "opacity-40"
+                  )}
+                  onClick={() => handleToggleSeries(item.userId)}
+                >
                   <span
                     className={clsx(
                       "inline-block w-2 h-2 rounded-full",
@@ -151,7 +195,7 @@ const SeasonPage: React.FC = () => {
                     )}
                   />
                   <span className="text-text-muted">{item.userName}</span>
-                </div>
+                </button>
               ))}
             </div>
             <p className="mt-2 text-[10px] text-text-muted">

--- a/frontend/src/app/league/[leagueId]/season/[seasonId]/page.tsx
+++ b/frontend/src/app/league/[leagueId]/season/[seasonId]/page.tsx
@@ -123,6 +123,7 @@ const SeasonPage: React.FC = () => {
                 <button
                   key={item.userId}
                   type="button"
+                  aria-pressed={visibleUserIds.includes(item.userId)}
                   className={clsx(
                     "flex min-h-7 items-center gap-1 rounded px-1 transition-opacity focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-pink-300",
                     visibleUserIds.some((userId) => userId === item.userId)
@@ -134,7 +135,7 @@ const SeasonPage: React.FC = () => {
                   <span
                     className={clsx(
                       "inline-block w-2 h-2 rounded-full",
-                      item.colorClassName
+                      item.strokeColor
                     )}
                   />
                   <span className="text-text-muted">{item.userName}</span>

--- a/frontend/src/app/league/[leagueId]/season/[seasonId]/page.tsx
+++ b/frontend/src/app/league/[leagueId]/season/[seasonId]/page.tsx
@@ -26,76 +26,19 @@ const formatDate = (value: string | null) => {
   }).format(new Date(value));
 };
 
-const CHART_STROKE_COLORS = [
-  "#ef4444",
-  "#3b82f6",
-  "#22c55e",
-  "#eab308",
-  "#a855f7",
-  "#ec4899",
-  "#f97316",
-  "#0ea5e9",
-  "#10b981",
-  "#f59e0b",
-  "#84cc16",
-  "#14b8a6",
-  "#06b6d4",
-  "#6366f1",
-  "#8b5cf6",
-  "#d946ef",
-  "#f43f5e",
-  "#db2777",
-  "#a16207",
-  "#78716c",
-  "#6b7280",
-  "#111827",
-];
-
 const SeasonPage: React.FC = () => {
   const {
     season,
     titles,
     pointProgressionChart,
+    chartSeries,
+    visibleSeries,
+    visibleUserIds,
     loading,
     error,
     handleStartRecording,
+    handleToggleChartSeries,
   } = useSeasonPage();
-
-  const chartSeries = React.useMemo(
-    () =>
-      pointProgressionChart.series.map((item, index) => ({
-        userId: item.userId,
-        userName: item.userName,
-        colorClassName: item.colorClassName,
-        strokeColor:
-          CHART_STROKE_COLORS[index % CHART_STROKE_COLORS.length] ?? "#111827",
-      })),
-    [pointProgressionChart.series]
-  );
-
-  const [visibleUserIds, setVisibleUserIds] = React.useState<string[]>([]);
-
-  React.useEffect(() => {
-    setVisibleUserIds(chartSeries.map((item) => item.userId));
-  }, [chartSeries]);
-
-  const visibleSeries = React.useMemo(
-    () =>
-      chartSeries.filter((item) =>
-        visibleUserIds.some((userId) => userId === item.userId)
-      ),
-    [chartSeries, visibleUserIds]
-  );
-
-  const handleToggleSeries = React.useCallback((userId: string) => {
-    setVisibleUserIds((prev) => {
-      if (prev.some((id) => id === userId)) {
-        return prev.filter((id) => id !== userId);
-      }
-
-      return [...prev, userId];
-    });
-  }, []);
 
   if (loading) {
     return (
@@ -186,7 +129,7 @@ const SeasonPage: React.FC = () => {
                       ? "opacity-100"
                       : "opacity-40"
                   )}
-                  onClick={() => handleToggleSeries(item.userId)}
+                  onClick={() => handleToggleChartSeries(item.userId)}
                 >
                   <span
                     className={clsx(

--- a/frontend/src/app/league/[leagueId]/season/[seasonId]/page.tsx
+++ b/frontend/src/app/league/[leagueId]/season/[seasonId]/page.tsx
@@ -5,10 +5,9 @@ import * as React from "react";
 import clsx from "clsx";
 import { Calendar, Crown } from "lucide-react";
 
-import { COLOR_MAP } from "@/constants/color-map";
-
 import Header from "@/components/common/container/header";
 import { LeagueRankingTable } from "@/components/pages/league/league-ranking-table";
+import { SeasonPointProgressionChart } from "@/components/pages/league/season-point-progression-chart";
 import { Button } from "@/components/ui/button";
 import { HeaderCard } from "@/components/ui/header-card";
 import { SectionCard } from "@/components/ui/section-card";
@@ -27,9 +26,52 @@ const formatDate = (value: string | null) => {
   }).format(new Date(value));
 };
 
+const CHART_STROKE_COLORS = [
+  "#ef4444",
+  "#3b82f6",
+  "#22c55e",
+  "#eab308",
+  "#a855f7",
+  "#ec4899",
+  "#f97316",
+  "#0ea5e9",
+  "#10b981",
+  "#f59e0b",
+  "#84cc16",
+  "#14b8a6",
+  "#06b6d4",
+  "#6366f1",
+  "#8b5cf6",
+  "#d946ef",
+  "#f43f5e",
+  "#db2777",
+  "#a16207",
+  "#78716c",
+  "#6b7280",
+  "#111827",
+];
+
 const SeasonPage: React.FC = () => {
-  const { season, titles, loading, error, handleStartRecording } =
-    useSeasonPage();
+  const {
+    season,
+    titles,
+    pointProgressionChart,
+    loading,
+    error,
+    handleStartRecording,
+  } = useSeasonPage();
+
+  const chartSeries = React.useMemo(
+    () =>
+      pointProgressionChart.series.map((item, index) => ({
+        userId: item.userId,
+        userName: item.userName,
+        colorClassName: item.colorClassName,
+        strokeColor:
+          CHART_STROKE_COLORS[index % CHART_STROKE_COLORS.length] ?? "#111827",
+      })),
+    [pointProgressionChart.series]
+  );
 
   if (loading) {
     return (
@@ -95,24 +137,20 @@ const SeasonPage: React.FC = () => {
 
         <section className="mb-8">
           <SectionCard title="総合pt推移" bodyClassName="p-4">
-            <div className="w-full h-48 bg-gray-50 rounded-md mb-3" />
+            <SeasonPointProgressionChart
+              data={pointProgressionChart.chartData}
+              series={chartSeries}
+            />
             <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs">
-              {season.pointProgressions.map((progression, index) => (
-                <div
-                  key={progression.userId}
-                  className="flex items-center gap-1"
-                >
+              {chartSeries.map((item) => (
+                <div key={item.userId} className="flex items-center gap-1">
                   <span
                     className={clsx(
                       "inline-block w-2 h-2 rounded-full",
-                      Object.values(COLOR_MAP)[
-                        index % Object.values(COLOR_MAP).length
-                      ]
+                      item.colorClassName
                     )}
                   />
-                  <span className="text-text-muted">
-                    {progression.userName}
-                  </span>
+                  <span className="text-text-muted">{item.userName}</span>
                 </div>
               ))}
             </div>

--- a/frontend/src/app/league/[leagueId]/season/[seasonId]/page.tsx
+++ b/frontend/src/app/league/[leagueId]/season/[seasonId]/page.tsx
@@ -162,7 +162,7 @@ const SeasonPage: React.FC = () => {
         <section className="mb-8">
           <SectionCard title="総合pt推移" bodyClassName="p-4">
             {pointProgressionChart.isChartEmpty ? (
-              <div className="mb-3 flex h-[220px] w-full items-center justify-center rounded-md bg-gray-50 text-sm text-text-muted">
+              <div className="mb-3 flex h-[clamp(200px,38vw,280px)] w-full items-center justify-center rounded-md bg-gray-50 px-4 text-center text-sm text-text-muted">
                 まだ対局データがないため、グラフを表示できません
               </div>
             ) : visibleSeries.length > 0 ? (
@@ -171,17 +171,17 @@ const SeasonPage: React.FC = () => {
                 series={visibleSeries}
               />
             ) : (
-              <div className="mb-3 flex h-[220px] w-full items-center justify-center rounded-md bg-gray-50 text-sm text-text-muted">
+              <div className="mb-3 flex h-[clamp(200px,38vw,280px)] w-full items-center justify-center rounded-md bg-gray-50 px-4 text-center text-sm text-text-muted">
                 凡例からプレイヤーを選択するとグラフを表示できます
               </div>
             )}
-            <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs">
+            <div className="flex flex-wrap gap-x-2 gap-y-2 text-xs sm:gap-x-4 sm:gap-y-1">
               {chartSeries.map((item) => (
                 <button
                   key={item.userId}
                   type="button"
                   className={clsx(
-                    "flex items-center gap-1 transition-opacity",
+                    "flex min-h-7 items-center gap-1 rounded px-1 transition-opacity focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-pink-300",
                     visibleUserIds.some((userId) => userId === item.userId)
                       ? "opacity-100"
                       : "opacity-40"
@@ -198,7 +198,7 @@ const SeasonPage: React.FC = () => {
                 </button>
               ))}
             </div>
-            <p className="mt-2 text-[10px] text-text-muted">
+            <p className="mt-2 text-xs text-text-muted sm:text-[10px]">
               ※プレイヤー名をタップするとデータを非表示にできます
             </p>
           </SectionCard>

--- a/frontend/src/components/pages/league/season-point-progression-chart/index.tsx
+++ b/frontend/src/components/pages/league/season-point-progression-chart/index.tsx
@@ -70,7 +70,7 @@ export const SeasonPointProgressionChart: React.FC<Props> = ({
             axisLine={false}
             width={52}
             tick={{ fill: "#6b7280", fontSize: 12 }}
-            tickFormatter={(value: number) => `${value}pt`}
+            tickFormatter={(value: number) => formatPoint(value)}
           />
           <ReferenceLine y={0} stroke="#9ca3af" strokeDasharray="4 4" />
           <Tooltip

--- a/frontend/src/components/pages/league/season-point-progression-chart/index.tsx
+++ b/frontend/src/components/pages/league/season-point-progression-chart/index.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import * as React from "react";
+
+import {
+  CartesianGrid,
+  Line,
+  LineChart,
+  ReferenceLine,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+type SeasonPointProgressionChartSeries = {
+  userId: string;
+  userName: string;
+  strokeColor: string;
+};
+
+type SeasonPointProgressionChartData = {
+  matchIndex: number;
+  [userId: string]: number;
+};
+
+type Props = {
+  data: SeasonPointProgressionChartData[];
+  series: SeasonPointProgressionChartSeries[];
+  height?: number;
+};
+
+const formatPoint = (value: number) => `${value.toFixed(1)}pt`;
+
+export const SeasonPointProgressionChart: React.FC<Props> = ({
+  data,
+  series,
+  height = 220,
+}) => {
+  return (
+    <div style={{ width: "100%", height }}>
+      <ResponsiveContainer>
+        <LineChart
+          data={data}
+          margin={{ top: 16, right: 20, left: 8, bottom: 4 }}
+        >
+          <CartesianGrid
+            strokeDasharray="3 3"
+            stroke="#f6b6c4"
+            vertical={false}
+          />
+          <XAxis
+            dataKey="matchIndex"
+            tickLine={false}
+            axisLine={{ stroke: "#f2a5b6" }}
+            tick={{ fill: "#6b7280", fontSize: 12 }}
+          />
+          <YAxis
+            tickLine={false}
+            axisLine={false}
+            width={52}
+            tick={{ fill: "#6b7280", fontSize: 12 }}
+            tickFormatter={(value: number) => `${value}pt`}
+          />
+          <ReferenceLine y={0} stroke="#9ca3af" strokeDasharray="4 4" />
+          <Tooltip
+            contentStyle={{
+              borderColor: "#f2a5b6",
+              borderRadius: "8px",
+              fontSize: "12px",
+            }}
+            formatter={(value: number | string) => {
+              const numericValue =
+                typeof value === "number" ? value : Number(value);
+              return Number.isFinite(numericValue)
+                ? formatPoint(numericValue)
+                : "-";
+            }}
+            labelFormatter={(label) => `対局 ${label}`}
+          />
+
+          {series.map((item) => (
+            <Line
+              key={item.userId}
+              type="monotone"
+              dataKey={item.userId}
+              name={item.userName}
+              stroke={item.strokeColor}
+              strokeWidth={2}
+              dot={false}
+              activeDot={{ r: 4 }}
+            />
+          ))}
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  );
+};

--- a/frontend/src/components/pages/league/season-point-progression-chart/index.tsx
+++ b/frontend/src/components/pages/league/season-point-progression-chart/index.tsx
@@ -32,6 +32,16 @@ type Props = {
 
 const formatPoint = (value: number) => `${value.toFixed(1)}pt`;
 
+const formatTooltipValue: NonNullable<
+  React.ComponentProps<typeof Tooltip>["formatter"]
+> = (value) => {
+  const singleValue = Array.isArray(value) ? value[0] : value;
+  const numericValue =
+    typeof singleValue === "number" ? singleValue : Number(singleValue);
+
+  return Number.isFinite(numericValue) ? formatPoint(numericValue) : "-";
+};
+
 export const SeasonPointProgressionChart: React.FC<Props> = ({
   data,
   series,
@@ -69,16 +79,7 @@ export const SeasonPointProgressionChart: React.FC<Props> = ({
               borderRadius: "8px",
               fontSize: "12px",
             }}
-            formatter={(value) => {
-              const singleValue = Array.isArray(value) ? value[0] : value;
-              const numericValue =
-                typeof singleValue === "number"
-                  ? singleValue
-                  : Number(singleValue);
-              return Number.isFinite(numericValue)
-                ? formatPoint(numericValue)
-                : "-";
-            }}
+            formatter={formatTooltipValue}
             labelFormatter={(label) => `対局 ${label}`}
           />
 

--- a/frontend/src/components/pages/league/season-point-progression-chart/index.tsx
+++ b/frontend/src/components/pages/league/season-point-progression-chart/index.tsx
@@ -27,7 +27,7 @@ type SeasonPointProgressionChartData = {
 type Props = {
   data: SeasonPointProgressionChartData[];
   series: SeasonPointProgressionChartSeries[];
-  height?: number;
+  height?: number | string;
 };
 
 const formatPoint = (value: number) => `${value.toFixed(1)}pt`;
@@ -35,7 +35,7 @@ const formatPoint = (value: number) => `${value.toFixed(1)}pt`;
 export const SeasonPointProgressionChart: React.FC<Props> = ({
   data,
   series,
-  height = 220,
+  height = "clamp(200px, 38vw, 280px)",
 }) => {
   return (
     <div style={{ width: "100%", height }}>
@@ -69,9 +69,12 @@ export const SeasonPointProgressionChart: React.FC<Props> = ({
               borderRadius: "8px",
               fontSize: "12px",
             }}
-            formatter={(value: number | string) => {
+            formatter={(value) => {
+              const singleValue = Array.isArray(value) ? value[0] : value;
               const numericValue =
-                typeof value === "number" ? value : Number(value);
+                typeof singleValue === "number"
+                  ? singleValue
+                  : Number(singleValue);
               return Number.isFinite(numericValue)
                 ? formatPoint(numericValue)
                 : "-";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,6 +95,9 @@ importers:
       react-redux:
         specifier: ^9.2.0
         version: 9.2.0(@types/react@19.2.14)(react@19.1.0)(redux@5.0.1)
+      recharts:
+        specifier: ^3.8.1
+        version: 3.8.1(@types/react@19.2.14)(react-dom@19.1.0(react@19.1.0))(react-is@16.13.1)(react@19.1.0)(redux@5.0.1)
     devDependencies:
       '@eslint/eslintrc':
         specifier: ^3
@@ -1344,6 +1347,33 @@ packages:
   '@types/caseless@0.12.5':
     resolution: {integrity: sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg==}
 
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-shape@3.1.8':
+    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -2097,6 +2127,50 @@ packages:
   csv-parse@5.6.0:
     resolution: {integrity: sha512-l3nz3euub2QMg5ouu5U09Ew9Wf6/wQ8I++ch1loQ0ljmzhmfZYrH9fflS22i/PQEvsPvxCwxgz5q7UB8K1JO4Q==}
 
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
 
@@ -2153,6 +2227,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js-light@2.5.1:
+    resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
 
   deep-equal-in-any-order@2.2.0:
     resolution: {integrity: sha512-lUYf3Oz/HrPcNmKe+S+QSdY5/hzKleftcFBWLwbHNZ5007RUKgN0asWlAHuQGvT9djYd9PYQFiu0TyNS+h3j/g==}
@@ -2295,6 +2372,9 @@ packages:
   es-to-primitive@1.3.0:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
+
+  es-toolkit@1.47.0:
+    resolution: {integrity: sha512-n1GuoD0WEQZMBk5tttoZSqwgyLx01oqa5XsBmCHwPyNe1S9jPBEmtR2pSgp2kJuWE3ciFZ6yRHmY4pM4C3OOkw==}
 
   esbuild@0.27.7:
     resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
@@ -2473,6 +2553,9 @@ packages:
   event-target-shim@5.0.1:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
     engines: {node: '>=6'}
+
+  eventemitter3@5.0.4:
+    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
   events-listener@1.1.0:
     resolution: {integrity: sha512-Kd3EgYfODHueq6GzVfs/VUolh2EgJsS8hkO3KpnDrxVjU3eq63eXM2ujXkhPP+OkeUOhL8CxdfZbQXzryb5C4g==}
@@ -2909,6 +2992,9 @@ packages:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
+  immer@10.2.0:
+    resolution: {integrity: sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==}
+
   immer@11.1.4:
     resolution: {integrity: sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==}
 
@@ -2944,6 +3030,10 @@ packages:
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   ip-address@10.1.0:
     resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
@@ -4123,6 +4213,14 @@ packages:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
 
+  recharts@3.8.1:
+    resolution: {integrity: sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-is: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   redux-thunk@3.1.0:
     resolution: {integrity: sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==}
     peerDependencies:
@@ -4534,6 +4632,9 @@ packages:
   through2@2.0.5:
     resolution: {integrity: sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==}
 
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
@@ -4722,6 +4823,9 @@ packages:
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
+
+  victory-vendor@37.3.6:
+    resolution: {integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==}
 
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
@@ -6077,6 +6181,30 @@ snapshots:
   '@types/caseless@0.12.5':
     optional: true
 
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-shape@3.1.8':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
   '@types/estree@1.0.8': {}
 
   '@types/json-schema@7.0.15': {}
@@ -6868,6 +6996,44 @@ snapshots:
 
   csv-parse@5.6.0: {}
 
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-color@3.1.0: {}
+
+  d3-ease@3.0.1: {}
+
+  d3-format@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@3.1.0: {}
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
   damerau-levenshtein@1.0.8: {}
 
   data-uri-to-buffer@4.0.1: {}
@@ -6907,6 +7073,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js-light@2.5.1: {}
 
   deep-equal-in-any-order@2.2.0:
     dependencies:
@@ -7107,6 +7275,8 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.1.0
       is-symbol: 1.1.1
+
+  es-toolkit@1.47.0: {}
 
   esbuild@0.27.7:
     optionalDependencies:
@@ -7369,6 +7539,8 @@ snapshots:
   etag@1.8.1: {}
 
   event-target-shim@5.0.1: {}
+
+  eventemitter3@5.0.4: {}
 
   events-listener@1.1.0: {}
 
@@ -8124,6 +8296,8 @@ snapshots:
 
   ignore@7.0.5: {}
 
+  immer@10.2.0: {}
+
   immer@11.1.4: {}
 
   import-fresh@3.3.1:
@@ -8151,6 +8325,8 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.2
       side-channel: 1.1.0
+
+  internmap@2.0.3: {}
 
   ip-address@10.1.0: {}
 
@@ -9342,6 +9518,26 @@ snapshots:
     dependencies:
       picomatch: 2.3.2
 
+  recharts@3.8.1(@types/react@19.2.14)(react-dom@19.1.0(react@19.1.0))(react-is@16.13.1)(react@19.1.0)(redux@5.0.1):
+    dependencies:
+      '@reduxjs/toolkit': 2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.1.0)(redux@5.0.1))(react@19.1.0)
+      clsx: 2.1.1
+      decimal.js-light: 2.5.1
+      es-toolkit: 1.47.0
+      eventemitter3: 5.0.4
+      immer: 10.2.0
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      react-is: 16.13.1
+      react-redux: 9.2.0(@types/react@19.2.14)(react@19.1.0)(redux@5.0.1)
+      reselect: 5.1.1
+      tiny-invariant: 1.3.3
+      use-sync-external-store: 1.6.0(react@19.1.0)
+      victory-vendor: 37.3.6
+    transitivePeerDependencies:
+      - '@types/react'
+      - redux
+
   redux-thunk@3.1.0(redux@5.0.1):
     dependencies:
       redux: 5.0.1
@@ -9921,6 +10117,8 @@ snapshots:
       readable-stream: 2.3.8
       xtend: 4.0.2
 
+  tiny-invariant@1.3.3: {}
+
   tinyglobby@0.2.16:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
@@ -10149,6 +10347,23 @@ snapshots:
   validate-npm-package-name@5.0.1: {}
 
   vary@1.1.2: {}
+
+  victory-vendor@37.3.6:
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-ease': 3.0.2
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-scale': 4.0.9
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-timer': 3.0.2
+      d3-array: 3.2.4
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-scale: 4.0.2
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-timer: 3.0.1
 
   wcwidth@1.0.1:
     dependencies:


### PR DESCRIPTION
## 概要
シーズン詳細画面に総合pt推移グラフを追加し、凡例トグルや空状態表示を含む表示改善を行いました。

## 変更内容
- Recharts を導入
- シーズン詳細データから、欠損時に前回値を引き継ぐグラフ用データ整形を追加
- 総合pt推移用の折れ線グラフコンポーネントを追加
- シーズン詳細画面にグラフを接続
- 凡例タップで系列の表示/非表示を切替できるように対応
- データ0件時 / 全系列非表示時の empty state 表示を追加
- モバイル表示を考慮したレスポンシブ調整
- チャート関連の表示状態を page から hook に移し、Tooltip formatter を関数切り出し

## 成果物
<img width="390" height="844" alt="image" src="https://github.com/user-attachments/assets/74669460-699b-4a2d-879f-90e317f5fe5a" />

## 関連 Issue
- resolves #57

## 補足 / コメント
- ルートでの `pnpm lint` は本変更以外の既存ファイルにも指摘があり失敗しますが、変更対象ファイルに限定した ESLint は通過しています。
- `pnpm typecheck` は backend / frontend ともに通過しています。
